### PR TITLE
Propagate exit code

### DIFF
--- a/Community.Wsl.Sdk.Tests/IntegrationsTests/ManagedCommandTests.cs
+++ b/Community.Wsl.Sdk.Tests/IntegrationsTests/ManagedCommandTests.cs
@@ -109,4 +109,36 @@ internal class ManagedCommandTests
         result.Stderr.Should().BeNull();
         result.StderrData.Should().BeNull();
     }
+
+    [Test]
+    public void Test_exit_code()
+    {
+        var cmd = new ManagedCommand(
+            _distroName,
+            "this_command_doesnt_exit",
+            new[] { "-n", "test" },
+            new CommandExecutionOptions() { FailOnNegativeExitCode = false }
+        );
+
+        cmd.Start();
+        var result = cmd.WaitAndGetResults();
+
+        result.ExitCode.Should().NotBe(0);
+    }
+
+    [Test]
+    public async Task Test_exit_code_async()
+    {
+        var cmd = new ManagedCommand(
+            _distroName,
+            "this_command_doesnt_exit",
+            new[] { "-n", "test" },
+            new CommandExecutionOptions() { FailOnNegativeExitCode = false }
+        );
+
+        cmd.Start();
+        var result = await cmd.WaitAndGetResultsAsync();
+
+        result.ExitCode.Should().NotBe(0);
+    }
 }

--- a/Community.Wsl.Sdk/Strategies/Command/ManagedCommand.cs
+++ b/Community.Wsl.Sdk/Strategies/Command/ManagedCommand.cs
@@ -222,7 +222,7 @@ public class ManagedCommand : ICommand
             throw new Exception($"Process exit code is non-zero: {_process.ExitCode}");
         }
 
-        var result = new CommandResult();
+        var result = new CommandResult() { ExitCode = _process.ExitCode };
 
         _stdoutReader.Wait();
         _stdoutReader.CopyResultTo(ref result, true);
@@ -247,14 +247,14 @@ public class ManagedCommand : ICommand
 
         _hasWaited = true;
 
-        await WaitForExit(_process!);
+        var exitCode = await WaitForExit(_process!);
 
-        if (_options.FailOnNegativeExitCode && _process!.ExitCode != 0)
+        if (_options.FailOnNegativeExitCode && exitCode != 0)
         {
-            throw new Exception($"Process exit code is non-zero: {_process.ExitCode}");
+            throw new Exception($"Process exit code is non-zero: {exitCode}");
         }
 
-        var result = new CommandResult();
+        var result = new CommandResult() { ExitCode = exitCode, };
 
         await _stdoutReader.WaitAsync();
         _stdoutReader.CopyResultTo(ref result, true);


### PR DESCRIPTION
Previously the exit code has been swallowed when `FailOnNegativeExitCode == false`.
Now the `ExitCode` will be set correctly.